### PR TITLE
Require scikit-image version >= 0.17

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
         'matplotlib',
         'meshio',
         'numpy',
-        'scikit-image',
+        'scikit-image>=0.17',
         'scipy',
         'Pillow',
     ],


### PR DESCRIPTION
In previous versions, there is no `skimage.measure.marching_cubes()`, it is instead named `skimage.measure.marching_cubes_lewinar()`, see https://scikit-image.org/docs/0.16.x/api/skimage.measure.html#marching-cubes-lewiner

The code as is results in no polygons generated for older scikit-image versions.