### PR TITLE
Added 2d generate support and mesh.show() previews based on matplotlib and vtkplotlib

### DIFF
--- a/examples/generate_2d.py
+++ b/examples/generate_2d.py
@@ -1,0 +1,7 @@
+from sdf import *
+import numpy as np
+
+f = rectangle(1) - circle(0.5)
+points = f.generate(workers=1)
+
+print(np.array(points).shape)

--- a/examples/show_2d.py
+++ b/examples/show_2d.py
@@ -1,0 +1,6 @@
+from sdf import *
+from matplotlib import pyplot as plt
+
+f = polygon([[0,0], [1,0], [0,1]]).translate([-3.5, -0.5]) | rectangle(1) |    circle(0.5).translate([3, 0])
+
+f.show()

--- a/examples/show_3d.py
+++ b/examples/show_3d.py
@@ -1,0 +1,11 @@
+from sdf import *
+  
+t = torus(2, 0.5)
+f = union(
+    t.orient(X),
+    t.orient(Y),
+    t.orient(Z),
+    k=0.1,
+)
+
+f.show()

--- a/sdf/d2.py
+++ b/sdf/d2.py
@@ -2,7 +2,7 @@ import functools
 import numpy as np
 import operator
 
-from . import dn, d3, ease
+from . import dn, d3, ease, mesh
 
 # Constants
 
@@ -20,6 +20,7 @@ _ops = {}
 class SDF2:
     def __init__(self, f):
         self.f = f
+        self.dim = 2
     def __call__(self, p):
         return self.f(p).reshape((-1, 1))
     def __getattr__(self, name):
@@ -36,6 +37,10 @@ class SDF2:
     def k(self, k=None):
         self._k = k
         return self
+    def generate(self, *args, **kwargs):
+        return mesh.generate(self, *args, **kwargs)
+    def show(self, *args, **kwargs):
+        return mesh.show(self, *args, **kwargs)
 
 def sdf2(f):
     def wrapper(*args, **kwargs):

--- a/sdf/d3.py
+++ b/sdf/d3.py
@@ -21,6 +21,7 @@ _ops = {}
 class SDF3:
     def __init__(self, f):
         self.f = f
+        self.dim = 3
     def __call__(self, p):
         return self.f(p).reshape((-1, 1))
     def __getattr__(self, name):
@@ -41,6 +42,8 @@ class SDF3:
         return mesh.generate(self, *args, **kwargs)
     def save(self, path, *args, **kwargs):
         return mesh.save(path, self, *args, **kwargs)
+    def show(self, *args, **kwargs):
+        return mesh.show(self, *args, **kwargs)
     def show_slice(self, *args, **kwargs):
         return mesh.show_slice(self, *args, **kwargs)
 


### PR DESCRIPTION
Added support for generate() to SDF2 based on scikit-image measure.fnd_contours().  Added show() to mesh.py using matplotlib for SDF2 and numpy-stl and vtkplotlib for SDF3. Note: vtkplotlib uses numpy-stl as a dependency.


Comments:
In order for generate and plot to determine the correct behavior, the dimension of sdf needs to be determined.  My original approach was to use isinstance(sdf, SDF2) and isinstance(sdf, SDF3) but this created a circular dependency.  I added a dimension parameter `self.dim` to each class that is used for checking.

The stl import in show() is for numpy-stl.  I realize this might cause confusion with the existing sdf.stl so I call attention to it here.

I did not implement SDF2 save().  The analogous output to stl might be csv.  Pandas may be provide similar flexibility for 2D tabular output files as what can be achieved for 3D meshes with meshio, or meshio may still be the appropriate choice for 2D.

I noticed some strange behavior with the union command.  The union() of two SDF2 objects is promoted to SDF3 but the same operation using the overloaded __or__ operator produces an SDF2 object.  More testing on SDF2 objects would be useful.

I added three examples demonstrating the new features.

This is my first pull request so I'd be interested to know what your thoughts are.  In general this is a great library to work with. 
 Thanks for sharing!